### PR TITLE
[-] Fix writeResult not writing result

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -33,3 +33,12 @@ func failOnErr(err error) {
 		log.Fatal(err)
 	}
 }
+
+func verifyCommand(command string, commands []string) {
+	for _, word := range words {
+		if strings.Contains(command, word) {
+			return true
+		}
+	}
+	return false
+}

--- a/helpers.go
+++ b/helpers.go
@@ -8,11 +8,15 @@ import (
 )
 
 func verifyPluginParameters(variables []string) {
+	var missing []string
 	for _, v := range variables {
 		if _, ok := os.LookupEnv(v); !ok {
-			log.Fatal(fmt.Sprintf("Some of required environment variables are not set (%s)",
-				strings.ReplaceAll(strings.Join(variables, " "), "PLUGIN_", "")))
+			missing = append(missing, strings.TrimPrefix(v, "PLUGIN_"))
 		}
+	}
+
+	if len(missing) > 0 {
+		log.Fatal(fmt.Sprintf("Some required environment variables are not set (%s)", strings.Join(missing, " ")))
 	}
 }
 

--- a/helpers.go
+++ b/helpers.go
@@ -16,7 +16,7 @@ func verifyPluginParameters(variables []string) {
 	}
 }
 
-func writeResult(results os.File, fields map[string]string) {
+func writeResult(results *os.File, fields map[string]string) {
 	for f, v := range fields {
 		line := fmt.Sprintf("%s=\"%s\"\n", f, strings.ReplaceAll(v, "\"", "\\\""))
 		fmt.Print(line)

--- a/helpers.go
+++ b/helpers.go
@@ -35,8 +35,8 @@ func failOnErr(err error) {
 }
 
 func verifyCommand(command string, commands []string) {
-	for _, word := range words {
-		if strings.Contains(command, word) {
+	for _, word := range commands {
+		if strings.Contains(command, commands) {
 			return true
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -31,14 +31,14 @@ func main() {
 	if strings.Contains(commands, "getPrDetails") {
 		verifyPluginParameters([]string{"PLUGIN_PR_NUMBER"})
 		fields := getPullRequest(client, &ctx, repositoryName, repositoryOwner, os.Getenv("PLUGIN_PR_NUMBER"))
-		writeResult(*results, fields)
+		writeResult(results, fields)
 	}
 	if strings.Contains(commands, "getChangedFiles") {
 		verifyPluginParameters([]string{"PLUGIN_PR_NUMBER"})
 		prFields := getPullRequest(client, &ctx, repositoryName, repositoryOwner, os.Getenv("PLUGIN_PR_NUMBER"))
 		//writeResult(*results, prFields)
 		fields := getChanges(client, &ctx, repositoryName, repositoryOwner, prFields["BASE_SHA"], prFields["HEAD_SHA"])
-		writeResult(*results, fields)
+		writeResult(results, fields)
 	}
 	if strings.Contains(commands, "setTag") {
 		verifyPluginParameters([]string{"PLUGIN_TAG_NAME", "PLUGIN_SHA"})
@@ -53,7 +53,7 @@ func main() {
 			os.Getenv("PLUGIN_PR_TITLE"),
 			os.Getenv("PLUGIN_PR_BODY"),
 			os.Getenv("PLUGIN_PR_LABELS"))
-		writeResult(*results, fields)
+		writeResult(results, fields)
 	}
 	if strings.Contains(commands, "AddPullRequestLabels") {
 		verifyPluginParameters([]string{"PLUGIN_PR_NUMBER", "PLUGIN_PR_LABELS"})
@@ -77,7 +77,7 @@ func main() {
 	if strings.Contains(commands, "getStatuses") {
 		verifyPluginParameters([]string{"PLUGIN_REF"})
 		fields := listStatusChecks(client, &ctx, repositoryName, repositoryOwner, os.Getenv("PLUGIN_REF"))
-		writeResult(*results, fields)
+		writeResult(results, fields)
 	}
 	if strings.Contains(commands, "waitForStatus") {
 		verifyPluginParameters([]string{"PLUGIN_REF", "PLUGIN_STATUS_CHECK_CONTEXT"})
@@ -85,7 +85,7 @@ func main() {
 			os.Getenv("PLUGIN_REF"),
 			os.Getenv("PLUGIN_STATUS_CHECK_CONTEXT"),
 			os.Getenv("PLUGIN_STATUS_CHECK_WAIT_TIMEOUT"))
-		writeResult(*results, fields)
+		writeResult(results, fields)
 	}
 	if strings.Contains(commands, "mergePr") {
 		verifyPluginParameters([]string{"PLUGIN_PR_NUMBER"})
@@ -96,7 +96,7 @@ func main() {
 	if strings.Contains(commands, "getRef") {
 		verifyPluginParameters([]string{"PLUGIN_REF"})
 		fields := getRef(client, &ctx, repositoryName, repositoryOwner, os.Getenv("PLUGIN_REF"))
-		writeResult(*results, fields)
+		writeResult(results, fields)
 	}
 	results.Close()
 

--- a/main.go
+++ b/main.go
@@ -32,7 +32,6 @@ func main() {
 
 	results, err := os.Create(outputFile)
 	failOnErr(err)
-	ranCommand:= false
 	if strings.Contains(commands, "getPrDetails") {
 		verifyPluginParameters([]string{"PLUGIN_PR_NUMBER"})
 		fields := getPullRequest(client, &ctx, repositoryName, repositoryOwner, os.Getenv("PLUGIN_PR_NUMBER"))

--- a/main.go
+++ b/main.go
@@ -28,10 +28,12 @@ func main() {
 
 	results, err := os.Create(outputFile)
 	failOnErr(err)
+	ranCommand:= false
 	if strings.Contains(commands, "getPrDetails") {
 		verifyPluginParameters([]string{"PLUGIN_PR_NUMBER"})
 		fields := getPullRequest(client, &ctx, repositoryName, repositoryOwner, os.Getenv("PLUGIN_PR_NUMBER"))
 		writeResult(results, fields)
+		ranCommand=true
 	}
 	if strings.Contains(commands, "getChangedFiles") {
 		verifyPluginParameters([]string{"PLUGIN_PR_NUMBER"})
@@ -39,11 +41,13 @@ func main() {
 		//writeResult(*results, prFields)
 		fields := getChanges(client, &ctx, repositoryName, repositoryOwner, prFields["BASE_SHA"], prFields["HEAD_SHA"])
 		writeResult(results, fields)
+		ranCommand=true
 	}
 	if strings.Contains(commands, "setTag") {
 		verifyPluginParameters([]string{"PLUGIN_TAG_NAME", "PLUGIN_SHA"})
 		tagName := "refs/tags/" + os.Getenv("PLUGIN_TAG_NAME")
 		updateCreateTag(client, &ctx, repositoryName, repositoryOwner, tagName, os.Getenv("PLUGIN_SHA"))
+		ranCommand=true
 	}
 	if strings.Contains(commands, "createPullRequest") {
 		verifyPluginParameters([]string{"PLUGIN_PR_SOURCE_BRANCH", "PLUGIN_PR_TARGET_BRANCH", "PLUGIN_PR_TITLE", "PLUGIN_PR_BODY"})
@@ -54,12 +58,14 @@ func main() {
 			os.Getenv("PLUGIN_PR_BODY"),
 			os.Getenv("PLUGIN_PR_LABELS"))
 		writeResult(results, fields)
+		ranCommand=true
 	}
 	if strings.Contains(commands, "AddPullRequestLabels") {
 		verifyPluginParameters([]string{"PLUGIN_PR_NUMBER", "PLUGIN_PR_LABELS"})
 		addPullRequestLabels(client, &ctx, repositoryName, repositoryOwner,
 			os.Getenv("PLUGIN_PR_NUMBER"),
 			os.Getenv("PLUGIN_PR_LABELS"))
+		ranCommand=true
 	}
 	if strings.Contains(commands, "setStatusCheck") {
 		verifyPluginParameters([]string{"PLUGIN_STATUS_CHECK_SHA",
@@ -73,11 +79,13 @@ func main() {
 			os.Getenv("PLUGIN_STATUS_CHECK_STATUS"),
 			os.Getenv("PLUGIN_STATUS_CHECK_URL"),
 			os.Getenv("PLUGIN_STATUS_CHECK_DESCRIPTION"))
+		ranCommand=true
 	}
 	if strings.Contains(commands, "getStatuses") {
 		verifyPluginParameters([]string{"PLUGIN_REF"})
 		fields := listStatusChecks(client, &ctx, repositoryName, repositoryOwner, os.Getenv("PLUGIN_REF"))
 		writeResult(results, fields)
+		ranCommand=true
 	}
 	if strings.Contains(commands, "waitForStatus") {
 		verifyPluginParameters([]string{"PLUGIN_REF", "PLUGIN_STATUS_CHECK_CONTEXT"})
@@ -86,18 +94,24 @@ func main() {
 			os.Getenv("PLUGIN_STATUS_CHECK_CONTEXT"),
 			os.Getenv("PLUGIN_STATUS_CHECK_WAIT_TIMEOUT"))
 		writeResult(results, fields)
+		ranCommand=true
 	}
 	if strings.Contains(commands, "mergePr") {
 		verifyPluginParameters([]string{"PLUGIN_PR_NUMBER"})
 		mergePullRequest(client, &ctx, repositoryName, repositoryOwner,
 			os.Getenv("PLUGIN_PR_NUMBER"),
 			os.Getenv("PLUGIN_MERGE_COMMENT"))
+		ranCommand=true
 	}
 	if strings.Contains(commands, "getRef") {
 		verifyPluginParameters([]string{"PLUGIN_REF"})
 		fields := getRef(client, &ctx, repositoryName, repositoryOwner, os.Getenv("PLUGIN_REF"))
 		writeResult(results, fields)
+		ranCommand=true
 	}
+    if !ranCommand{
+        fmt.Print("Never ran any commands")
+    }
 	results.Close()
 
 	out, err := exec.Command("cp", "-v", outputFile, copyOutputFile).Output()


### PR DESCRIPTION
Hello, I'm onboarding to this project, and as I was getting setup I noticed a few things:
1. The function writeResult takes in a value and not a reference. This means when you want to pass values between steps, there's no way to grab the PR number from the `Create Pull Request` step and pass it somewhere else. 
2. If the `command` is not defined or not valid, there's no way to know. The docker image I was testing from `datarobotdev` did not have `AddPullRequestLabels` and there was just no way to know that was a no-op. I can see a world where someone uses `addPullRequestLabels` instead and gets stuck.
3. In the `verifyPluginParameters` there wasn't a good way to know what values were actually missing, now we can see clearly when one or two are not there .